### PR TITLE
Fix false detection problem on IOS Instagram in-app browser

### DIFF
--- a/src/BrowserDetector/Browsers/Instagram.cs
+++ b/src/BrowserDetector/Browsers/Instagram.cs
@@ -1,0 +1,44 @@
+﻿namespace Shyjus.BrowserDetection
+{
+    using System;
+
+    /// <summary>
+    /// Represents an instance of Instagram Browser
+    /// Sample user agent string: Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Instagram 147.0.0.30.121 (iPhone9,3; iOS 12_4_1; tr_TR; tr-TR; scale=2.00; 750x1334; 224680684)
+    /// </summary>
+    internal class Instagram : Browser
+    {
+        public Instagram(ReadOnlySpan<char> userAgent, string version)
+            : base(userAgent, version)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override string Name => BrowserNames.Instagram;
+
+        /// <summary>
+        /// Populates a Instagram browser object from the userAgent value passed in. A return value indicates the parsing and populating the browser instance succeeded.
+        /// </summary>
+        /// <param name="userAgent">User agent value.</param>
+        /// <param name="result">When this method returns True, the result will contain a Instagram object populated.</param>
+        /// <returns>True if parsing succeeded, else False.</returns>
+        public static bool TryParse(ReadOnlySpan<char> userAgent, out Instagram result)
+        {
+            var instagramIndex = userAgent.IndexOf("Instagram ".AsSpan());
+
+            // Instagram should have "Instagram" words in it.
+            if (instagramIndex > -1)
+            {
+                var instagramVersion = GetVersionIfKeyPresent(userAgent, "Instagram ");
+                if (instagramVersion != null)
+                {
+                    result = new Instagram(userAgent, instagramVersion);
+                    return true;
+                }
+            }
+
+            result = null;
+            return false;
+        }
+    }
+}

--- a/src/BrowserDetector/Constants/BrowserNames.cs
+++ b/src/BrowserDetector/Constants/BrowserNames.cs
@@ -12,5 +12,6 @@
         public const string Safari = "Safari";
         public const string EdgeChromium = "EdgeChromium";
         public const string InternetExplorer = "InternetExplorer";
+        public const string Instagram = "Instagram";
     }
 }

--- a/src/BrowserDetector/Detection/Detector.cs
+++ b/src/BrowserDetector/Detection/Detector.cs
@@ -52,6 +52,11 @@
                 return safari;
             }
 
+            if (Instagram.TryParse(userAgentString, out var instagram))
+            {
+                return instagram;
+            }
+
             return default;
         }
     }

--- a/tests/BrowserDetector.Tests/InstagramTests.cs
+++ b/tests/BrowserDetector.Tests/InstagramTests.cs
@@ -1,0 +1,33 @@
+﻿namespace BrowserDetector.Tests
+{
+    using Shyjus.BrowserDetection;
+    using Shyjus.BrowserDetection.Tests;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for Instagram.
+    /// </summary>
+    public class InstagramTests
+    {
+        [Fact]
+        public void Instagram_IPad()
+        {
+            var isInstagram = Instagram.TryParse(UserAgents.Instagram_IPad, out var browser);
+
+            Assert.True(isInstagram);
+            Assert.Equal(BrowserNames.Instagram, browser.Name);
+            Assert.Equal(DeviceTypes.Tablet, browser.DeviceType);
+            Assert.Equal(OperatingSystems.IOS, browser.OS);
+        }
+
+        [Fact]
+        public void Instagram_IPhone()
+        {
+            var isChrome = Instagram.TryParse(UserAgents.Instagram_IPhone, out var browser);
+
+            Assert.True(isChrome);
+            Assert.Equal(DeviceTypes.Mobile, browser.DeviceType);
+            Assert.Equal(OperatingSystems.IOS, browser.OS);
+        }
+    }
+}

--- a/tests/BrowserDetector.Tests/UserAgents.cs
+++ b/tests/BrowserDetector.Tests/UserAgents.cs
@@ -38,6 +38,9 @@
         public const string Safari_IPhone = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Mobile/15E148 Safari/604.1";
         public const string Safari_IPad = "Mozilla/5.0 (iPad; CPU OS 10_3_3 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.0 Mobile/14G60 Safari/602.1";
 
+        public const string Instagram_IPhone = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Instagram 147.0.0.30.121 (iPhone9,3; iOS 12_4_1; tr_TR; tr-TR; scale=2.00; 750x1334; 224680684)";
+        public const string Instagram_IPad = "Mozilla/5.0 (iPad; CPU OS 13_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Instagram 132.1.0.21.129 (iPad5,1; iOS 13_5_1; tr_TR; tr-TR; scale=2.00; 750x1334; 202764138)";
+
         // Mobile IOS
 
         // Mobile Android


### PR DESCRIPTION
I have created a new type of browser to detect IOS Instagram in-app browser and added unit tests that prove my fix works.